### PR TITLE
new Function createTableColumn - for fixing MissingColumnIssues

### DIFF
--- a/src/main/java/de/akquinet/jbosscc/guttenbase/tools/schema/SchemaScriptCreatorTool.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/tools/schema/SchemaScriptCreatorTool.java
@@ -331,7 +331,7 @@ public class SchemaScriptCreatorTool {
 
 
   public String createTableColumn(final ColumnMetaData columnMetaData) throws SQLException {
-    return "ALTER TABLE " + getTableName(columnMetaData.getTableMetaData()) + " ADD " + createColumn(columnMetaData);
+    return "ALTER TABLE " + getTableName(columnMetaData.getTableMetaData()) + " ADD " + createColumn(columnMetaData)+";";
   }
 
   public String getTargetConnectorId() {

--- a/src/main/java/de/akquinet/jbosscc/guttenbase/tools/schema/SchemaScriptCreatorTool.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/tools/schema/SchemaScriptCreatorTool.java
@@ -331,7 +331,7 @@ public class SchemaScriptCreatorTool {
 
 
   public String createTableColumn(final ColumnMetaData columnMetaData) throws SQLException {
-    return "ALTER TABLE " + getTableName(columnMetaData.getTableMetaData()) + " ADD COLUMN " + createColumn(columnMetaData);
+    return "ALTER TABLE " + getTableName(columnMetaData.getTableMetaData()) + " ADD " + createColumn(columnMetaData);
   }
 
   public String getTargetConnectorId() {

--- a/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
@@ -202,7 +202,7 @@ public class DatabaseSchemaScriptCreatorTest {
   public void createColumn() throws SQLException {
     final String sql = _objectUnderTest.createTableColumn(_databaseMetaData.getTableMetaData().get(0).getColumnMetaData().get(1));
 
-    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD NAME VARCHAR(100) NOT NULL",sql);
+    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD NAME VARCHAR(100) NOT NULL;",sql);
   }
 
   @Test

--- a/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
@@ -199,6 +199,13 @@ public class DatabaseSchemaScriptCreatorTest {
   }
 
   @Test
+  public void createColumn() throws SQLException {
+    final String sql = _objectUnderTest.createTableColumn(_databaseMetaData.getTableMetaData().get(0).getColumnMetaData().get(1));
+
+    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD COLUMN NAME VARCHAR(100) NOT NULL",sql);
+  }
+
+  @Test
   public void testIndex() throws Exception {
     final ColumnMetaData columnMetaData = _databaseMetaData.getTableMetaData().get(0).getColumnMetaData("name");
     final IndexMetaData index = _databaseMetaData.getTableMetaData().get(0).getIndexesContainingColumn(columnMetaData).get(0);

--- a/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
@@ -202,7 +202,7 @@ public class DatabaseSchemaScriptCreatorTest {
   public void createColumn() throws SQLException {
     final String sql = _objectUnderTest.createTableColumn(_databaseMetaData.getTableMetaData().get(0).getColumnMetaData().get(1));
 
-    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD COLUMN NAME VARCHAR(100) NOT NULL",sql);
+    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD NAME VARCHAR(100) NOT NULL",sql);
   }
 
   @Test


### PR DESCRIPTION
Currently it is not possible to alter a table and add a column which was identified by a MissingColumnIssue.
Most of the functionality is already accessible. I added a method which generates the correct SQL-Statement for this case.