### PR TITLE
identify_identity_column_is_mssql-server

### DIFF
--- a/src/main/java/de/akquinet/jbosscc/guttenbase/configuration/impl/MsSqlTargetDatabaseConfiguration.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/configuration/impl/MsSqlTargetDatabaseConfiguration.java
@@ -96,11 +96,16 @@ public class MsSqlTargetDatabaseConfiguration extends DefaultTargetDatabaseConfi
 
   private boolean hasIdentityColumn(final TableMetaData tableMetaData) {
     for (final ColumnMetaData columnMetaData : tableMetaData.getColumnMetaData()) {
-      if (columnMetaData.getColumnTypeName().contains("IDENTITY")) {
+      if (isIdentityColumn(columnMetaData)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private boolean isIdentityColumn(ColumnMetaData columnMetaData) {
+    return columnMetaData.getColumnTypeName().toUpperCase().contains("IDENTITY")
+      || (columnMetaData.isPrimaryKey() && columnMetaData.isAutoIncrement() && columnMetaData.getTableMetaData().getPrimaryKeyColumns().size() == 1);
   }
 }

--- a/src/main/java/de/akquinet/jbosscc/guttenbase/statements/SelectStatementCreator.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/statements/SelectStatementCreator.java
@@ -1,8 +1,5 @@
 package de.akquinet.jbosscc.guttenbase.statements;
 
-import java.sql.SQLException;
-import java.sql.Types;
-
 import de.akquinet.jbosscc.guttenbase.connector.DatabaseType;
 import de.akquinet.jbosscc.guttenbase.meta.ColumnMetaData;
 import de.akquinet.jbosscc.guttenbase.meta.TableMetaData;

--- a/src/main/java/de/akquinet/jbosscc/guttenbase/statements/SelectStatementCreator.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/statements/SelectStatementCreator.java
@@ -1,5 +1,8 @@
 package de.akquinet.jbosscc.guttenbase.statements;
 
+import java.sql.SQLException;
+import java.sql.Types;
+
 import de.akquinet.jbosscc.guttenbase.connector.DatabaseType;
 import de.akquinet.jbosscc.guttenbase.meta.ColumnMetaData;
 import de.akquinet.jbosscc.guttenbase.meta.TableMetaData;
@@ -29,10 +32,11 @@ public class SelectStatementCreator extends AbstractSelectStatementCreator {
     final StringBuilder buf = new StringBuilder("ORDER BY ");
     int columnsAdded = 0;
 
-    // No BLOB or the like for ordering
-    final boolean isOracle = DatabaseType.ORACLE.equals(tableMetaData.getDatabaseMetaData().getDatabaseType());
-    final int rangeFrom = isOracle ? Types.NULL : Types.LONGNVARCHAR; // Doesn't like LONG e.g.
-    final int rangeTo = Types.JAVA_OBJECT;
+		// No BLOB or the like for ordering
+		final boolean isOracleOrMssql = DatabaseType.ORACLE.equals(tableMetaData.getDatabaseMetaData().getDatabaseType())
+				|| DatabaseType.MSSQL.equals(tableMetaData.getDatabaseMetaData().getDatabaseType());
+		final int rangeFrom = isOracleOrMssql ? Types.NULL : Types.LONGNVARCHAR; // Doesn't like LONG e.g.
+		final int rangeTo = Types.JAVA_OBJECT;
 
     for (int i = 0; i < tableMetaData.getColumnCount(); i++) {
       final ColumnMetaData columnMetaData = tableMetaData.getColumnMetaData().get(i);

--- a/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/guttenbase/utils/DatabaseSchemaScriptCreatorTest.java
@@ -199,6 +199,13 @@ public class DatabaseSchemaScriptCreatorTest {
   }
 
   @Test
+  public void createColumn() throws SQLException {
+    final String sql = _objectUnderTest.createTableColumn(_databaseMetaData.getTableMetaData().get(0).getColumnMetaData().get(1));
+
+    assertEquals("ALTER TABLE schemaName.MY_TABLE1 ADD COLUMN NAME VARCHAR(100) NOT NULL",sql);
+  }
+
+  @Test
   public void testIndex() throws Exception {
     final ColumnMetaData columnMetaData = _databaseMetaData.getTableMetaData().get(0).getColumnMetaData("name");
     final IndexMetaData index = _databaseMetaData.getTableMetaData().get(0).getIndexesContainingColumn(columnMetaData).get(0);


### PR DESCRIPTION
It is possible that the Microsoft Jdbc-Driver does not contains the identity word in the ColumnMetaData#databaseType.
In this case it is useful to detect the identity column in a second way.