### PR TITLE
identify Identity-Column in MSSQL-Server in a second way

### DIFF
--- a/src/main/java/de/akquinet/jbosscc/guttenbase/configuration/impl/MsSqlTargetDatabaseConfiguration.java
+++ b/src/main/java/de/akquinet/jbosscc/guttenbase/configuration/impl/MsSqlTargetDatabaseConfiguration.java
@@ -96,11 +96,16 @@ public class MsSqlTargetDatabaseConfiguration extends DefaultTargetDatabaseConfi
 
   private boolean hasIdentityColumn(final TableMetaData tableMetaData) {
     for (final ColumnMetaData columnMetaData : tableMetaData.getColumnMetaData()) {
-      if (columnMetaData.getColumnTypeName().contains("IDENTITY")) {
+      if (isIdentityColumn(columnMetaData)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private boolean isIdentityColumn(ColumnMetaData columnMetaData) {
+    return columnMetaData.getColumnTypeName().toUpperCase().contains("IDENTITY")
+      || (columnMetaData.isPrimaryKey() && columnMetaData.isAutoIncrement() && columnMetaData.getTableMetaData().getPrimaryKeyColumns().size() == 1);
   }
 }


### PR DESCRIPTION
It is possible that the Microsoft Jdbc-Driver does not contains the identity word in the ColumnMetaData#databaseType.
In this case it is useful to detect the identity column in a second way.

Now with the correct base branch ...